### PR TITLE
Add/landLinePrefix

### DIFF
--- a/lib/city.js
+++ b/lib/city.js
@@ -26,7 +26,7 @@ const getCitiesByStateName = (states, state) => states
 export const getCities = (states, id, state, cityName) => {
   if (id) {
     if (isNaN(id)) {
-      const error = new Error('Invalid id parameter, id most be number');
+      const error = new Error('Invalid id parameter, id must be number');
       throw error;
     }
     return getCitiesByStateId(states, Number(id));

--- a/lib/state.js
+++ b/lib/state.js
@@ -12,10 +12,14 @@ const getStatesByName = (states, state) => states
   .filter(({ name }) => name.includes(state))
   .map((state) => _.omit(state, 'cities'));
 
-export const getStates = (states, id, state) => {
+const getStatesByLandlinePrefix = (states, landlineCode) => states
+  .filter(({landlinePrefix}) => landlinePrefix === landlineCode)
+  .map((state) => _.omit(state, 'cities'));
+
+export const getStates = (states, id, state , landlinePrefix) => {
   if (id) {
     if (isNaN(id)) {
-      const error = new Error('Invalid id parameter, id most be number');
+      const error = new Error('Invalid id parameter, id must be number');
       throw error;
     }
     return getStatesById(states, Number(id));
@@ -23,6 +27,14 @@ export const getStates = (states, id, state) => {
 
   if (state) {
     return getStatesByName(states, state);
+  }
+
+  if(landlinePrefix){
+    if (!landlinePrefix.startsWith('0')) {
+      const error = new Error('Invalid landlinePrefix parameter, landlinePrefix must be started with 0');
+      throw error;
+    }
+    return getStatesByLandlinePrefix(states , landlinePrefix);
   }
 
   return getAllStates(states);

--- a/pages/api/v1/en/states.js
+++ b/pages/api/v1/en/states.js
@@ -5,10 +5,10 @@ const states = require('../../../../public/iran_cities_in_english.json');
 
 export default async function handler(req, res) {
   cors(req, res);
-  const { id, state } = req.query;
+  const { id, state , landlinePrefix } = req.query;
 
   try {
-    const matchedStates = getStates(states, id, state);
+    const matchedStates = getStates(states, id, state , landlinePrefix);
     return res.status(200).json(matchedStates);
   } catch (error) {
     return res.status(400).json({

--- a/pages/api/v1/fa/states.js
+++ b/pages/api/v1/fa/states.js
@@ -5,10 +5,10 @@ const states = require('../../../../public/iran_cities_with_coordinates.json');
 
 export default async function handler(req, res) {
   cors(req, res);
-  const { id, state } = req.query;
+  const { id, state , landlinePrefix } = req.query;
 
   try {
-    const matchedStates = getStates(states, id, state);
+    const matchedStates = getStates(states, id, state , landlinePrefix);
     return res.status(200).json(matchedStates);
   } catch (error) {
     return res.status(400).json({

--- a/public/iran_cities_in_english.json
+++ b/public/iran_cities_in_english.json
@@ -4,6 +4,7 @@
 		"center": "Tabriz",
 		"latitude": "38.50",
 		"longitude": "46.180",
+		"landlinePrefix" : "041",
 		"cities": [
 			{ "name": "Tabriz", "latitude": "38.50", "longitude": "46.180", "id": 1 },
 			{
@@ -141,6 +142,7 @@
 		"center": "Urmia",
 		"latitude": "37.320",
 		"longitude": "45.40",
+		"landlinePrefix" : "044",
 		"cities": [
 			{ "name": "Urmia", "latitude": "37.320", "longitude": "45.40", "id": 1 },
 			{
@@ -225,6 +227,7 @@
 		"center": "Ardabil",
 		"latitude": "38.140",
 		"longitude": "48.170",
+		"landlinePrefix" : "045",
 		"cities": [
 			{
 				"name": "Ardabil",
@@ -261,6 +264,7 @@
 		"center": "Isfahan",
 		"latitude": "32.390",
 		"longitude": "51.400",
+		"landlinePrefix" : "031",
 		"cities": [
 			{
 				"name": "Isfahan",
@@ -409,6 +413,7 @@
 		"center": "Ilam",
 		"latitude": "33.380",
 		"longitude": "46.250",
+		"landlinePrefix" : "084",
 		"cities": [
 			{ "name": "Ilam", "latitude": "33.380", "longitude": "46.250", "id": 1 },
 			{ "name": "Mehran", "latitude": "33.70", "longitude": "46.100", "id": 2 },
@@ -450,6 +455,7 @@
 		"center": "Bushehr",
 		"latitude": "28.590",
 		"longitude": "50.500",
+		"landlinePrefix" : "077",
 		"cities": [
 			{
 				"name": "Bushehr",
@@ -494,6 +500,7 @@
 		"center": "Tehran",
 		"latitude": "35.410",
 		"longitude": "51.240",
+		"landlinePrefix" : "021",
 		"cities": [
 			{
 				"name": "Tehran",
@@ -624,6 +631,7 @@
 		"center": "Shahrekord",
 		"latitude": "32.190",
 		"longitude": "50.510",
+		"landlinePrefix" : "038",
 		"cities": [
 			{
 				"name": "Shahrekord",
@@ -669,6 +677,7 @@
 		"center": "Birjand",
 		"latitude": "32.5216",
 		"longitude": "59.1315",
+		"landlinePrefix" : "056",
 		"cities": [
 			{ "name": "Qaen", "latitude": "33.430", "longitude": "59.60", "id": 1 },
 			{ "name": "Ferdows", "latitude": "34.00", "longitude": "58.90", "id": 2 },
@@ -704,6 +713,7 @@
 		"center": "Mashhad",
 		"latitude": "36.170",
 		"longitude": "59.350",
+		"landlinePrefix" : "051",
 		"cities": [
 			{
 				"name": "Mashhad",
@@ -799,6 +809,7 @@
 		"center": "Bojnourd",
 		"latitude": "37.2835",
 		"longitude": "57.1954",
+		"landlinePrefix" : "058",
 		"cities": [
 			{
 				"name": "Bojnourd",
@@ -838,6 +849,7 @@
 		"center": "Ahvaz",
 		"latitude": "31.190",
 		"longitude": "48.410",
+		"landlinePrefix" : "061",
 		"cities": [
 			{ "name": "Ahvaz", "latitude": "31.190", "longitude": "48.410", "id": 1 },
 			{
@@ -976,6 +988,7 @@
 		"center": "Zanjan",
 		"latitude": "36.400",
 		"longitude": "48.290",
+		"landlinePrefix" : "024",
 		"cities": [
 			{
 				"name": "Zanjan",
@@ -1022,6 +1035,7 @@
 		"center": "Semnan",
 		"latitude": "35.340",
 		"longitude": "53.230",
+		"landlinePrefix" : "023",
 		"cities": [
 			{
 				"name": "Semnan",
@@ -1062,6 +1076,7 @@
 		"center": "Zahedan",
 		"latitude": "29.320",
 		"longitude": "60.540",
+		"landlinePrefix" : "054",
 		"cities": [
 			{
 				"name": "Zahedan",
@@ -1109,6 +1124,7 @@
 		"center": "Shiraz",
 		"latitude": "29.360",
 		"longitude": "52.310",
+		"landlinePrefix" : "071",
 		"cities": [
 			{
 				"name": "Shiraz",
@@ -1244,6 +1260,7 @@
 		"center": "Qazvin",
 		"latitude": "36.167",
 		"longitude": "50.010",
+		"landlinePrefix" : "028",
 		"cities": [
 			{
 				"name": "Qazvin",
@@ -1272,6 +1289,7 @@
 		"center": "Qom",
 		"latitude": "34.380",
 		"longitude": "50.530",
+		"landlinePrefix" : "025",
 		"cities": [
 			{ "name": "Qom", "latitude": "34.380", "longitude": "50.530", "id": 1 },
 			{
@@ -1307,6 +1325,7 @@
 		"center": "Karaj",
 		"latitude": "35.8400",
 		"longitude": "50.9391",
+		"landlinePrefix" : "026",
 		"cities": [
 			{
 				"name": "Karaj",
@@ -1353,6 +1372,7 @@
 		"center": "Sanandaj",
 		"latitude": "35.180",
 		"longitude": "47.10",
+		"landlinePrefix" : "087",
 		"cities": [
 			{
 				"name": "Sanandaj",
@@ -1395,6 +1415,7 @@
 		"center": "Kerman",
 		"latitude": "30.160",
 		"longitude": "57.40",
+		"landlinePrefix" : "034",
 		"cities": [
 			{ "name": "Kerman", "latitude": "30.160", "longitude": "57.40", "id": 1 },
 			{ "name": "Ravar", "latitude": "31.150", "longitude": "56.510", "id": 2 },
@@ -1451,6 +1472,7 @@
 		"center": "Kermanshah",
 		"latitude": "34.180",
 		"longitude": "47.30",
+		"landlinePrefix" : "083",
 		"cities": [
 			{
 				"name": "Kermanshah",
@@ -1509,6 +1531,7 @@
 		"center": "Yasuj",
 		"latitude": "30.390",
 		"longitude": "51.350",
+		"landlinePrefix" : "074",
 		"cities": [
 			{ "name": "Yasuj", "latitude": "30.390", "longitude": "51.350", "id": 1 },
 			{
@@ -1543,6 +1566,7 @@
 		"center": "Gorgan",
 		"latitude": "36.500",
 		"longitude": "54.250",
+		"landlinePrefix" : "017",
 		"cities": [
 			{
 				"name": "Gorgan",
@@ -1595,6 +1619,7 @@
 		"center": "Rasht",
 		"latitude": "37.160",
 		"longitude": "49.350",
+		"landlinePrefix" : "013",
 		"cities": [
 			{ "name": "Rasht", "latitude": "37.160", "longitude": "49.350", "id": 1 },
 			{
@@ -1673,6 +1698,7 @@
 		"center": "Khorramabad",
 		"latitude": "33.290",
 		"longitude": "48.210",
+		"landlinePrefix" : "066",
 		"cities": [
 			{
 				"name": "Khorramabad",
@@ -1737,6 +1763,7 @@
 		"center": "Sari",
 		"latitude": "36.330",
 		"longitude": "53.30",
+		"landlinePrefix" : "011",
 		"cities": [
 			{ "name": "Sari", "latitude": "36.330", "longitude": "53.30", "id": 1 },
 			{ "name": "Amol", "latitude": "36.280", "longitude": "52.220", "id": 2 },
@@ -1811,6 +1838,7 @@
 		"center": "Arak",
 		"latitude": "34.50",
 		"longitude": "49.410",
+		"landlinePrefix" : "086",
 		"cities": [
 			{ "name": "Arak", "latitude": "34.50", "longitude": "49.410", "id": 1 },
 			{
@@ -1863,6 +1891,7 @@
 		"center": "Bandar Abbas",
 		"latitude": "56.266",
 		"longitude": "27.18",
+		"landlinePrefix" : "076",
 		"cities": [
 			{
 				"name": "Bandar Abbas",
@@ -1918,6 +1947,7 @@
 		"center": "Hamadan",
 		"latitude": "34.470",
 		"longitude": "48.300",
+		"landlinePrefix" : "081",
 		"cities": [
 			{
 				"name": "Hamadan",
@@ -1958,6 +1988,7 @@
 		"center": "Yazd",
 		"latitude": "31.530",
 		"longitude": "54.210",
+		"landlinePrefix" : "035",
 		"cities": [
 			{ "name": "Yazd", "latitude": "31.530", "longitude": "54.210", "id": 1 },
 			{ "name": "Taft", "latitude": "31.450", "longitude": "54.120", "id": 2 },

--- a/public/iran_cities_with_coordinates.json
+++ b/public/iran_cities_with_coordinates.json
@@ -4,6 +4,7 @@
     "center": "تبریز",
     "latitude": "38.50",
     "longitude": "46.180",
+    "landlinePrefix" : "041",
     "cities": [
       { "name": "تبريز", "latitude": "38.50", "longitude": "46.180", "id": 1 },
       {
@@ -121,6 +122,7 @@
     "center": "ارومیه",
     "latitude": "37.320",
     "longitude": "45.40",
+    "landlinePrefix" : "044",
     "cities": [
       { "name": "اروميه", "latitude": "37.320", "longitude": "45.40", "id": 1 },
       {
@@ -200,6 +202,7 @@
     "center": "اردبیل",
     "latitude": "38.140",
     "longitude": "48.170",
+    "landlinePrefix" : "045",
     "cities": [
       {
         "name": "اردبيل",
@@ -236,6 +239,7 @@
     "center": "اصفهان",
     "latitude": "32.390",
     "longitude": "51.400",
+    "landlinePrefix" : "031",
     "cities": [
       {
         "name": "اصفهان",
@@ -374,6 +378,7 @@
     "center": "ايلام",
     "latitude": "33.380",
     "longitude": "46.250",
+    "landlinePrefix" : "084",
     "cities": [
       { "name": "ايلام", "latitude": "33.380", "longitude": "46.250", "id": 1 },
       { "name": "مهران", "latitude": "33.70", "longitude": "46.100", "id": 2 },
@@ -415,6 +420,7 @@
     "center": "بوشهر",
     "latitude": "28.590",
     "longitude": "50.500",
+    "landlinePrefix" : "077",
     "cities": [
       { "name": "بوشهر", "latitude": "28.590", "longitude": "50.500", "id": 1 },
       { "name": "دير", "latitude": "27.510", "longitude": "51.590", "id": 2 },
@@ -444,6 +450,7 @@
     "center": "تهران",
     "latitude": "35.410",
     "longitude": "51.240",
+    "landlinePrefix" : "021",
     "cities": [
       { "name": "تهران", "latitude": "35.410", "longitude": "51.240", "id": 1 },
       {
@@ -554,6 +561,7 @@
     "center": "شهركرد",
     "latitude": "32.190",
     "longitude": "50.510",
+    "landlinePrefix" : "038",
     "cities": [
       {
         "name": "شهركرد",
@@ -584,6 +592,7 @@
     "center": "بيرجند",
     "latitude": "32.5216",
     "longitude": "59.1315",
+    "landlinePrefix" : "056",
     "cities": [
       { "name": "قائن", "latitude": "33.430", "longitude": "59.60", "id": 1 },
       { "name": "فردوس", "latitude": "34.00", "longitude": "58.90", "id": 2 },
@@ -614,6 +623,7 @@
     "center": "مشهد",
     "latitude": "36.170",
     "longitude": "59.350",
+    "landlinePrefix" : "051",
     "cities": [
       { "name": "مشهد", "latitude": "36.170", "longitude": "59.350", "id": 1 },
       {
@@ -693,6 +703,7 @@
     "center": "بجنورد",
     "latitude": "37.2835",
     "longitude": "57.1954",
+    "landlinePrefix" : "058",
     "cities": [
       {
         "name": "بجنورد",
@@ -732,6 +743,7 @@
     "center": "اهواز",
     "latitude": "31.190",
     "longitude": "48.410",
+    "landlinePrefix" : "061",
     "cities": [
       { "name": "اهواز", "latitude": "31.190", "longitude": "48.410", "id": 1 },
       {
@@ -865,6 +877,7 @@
     "center": "زنجان",
     "latitude": "36.400",
     "longitude": "48.290",
+    "landlinePrefix" : "024",
     "cities": [
       { "name": "زنجان", "latitude": "36.400", "longitude": "48.290", "id": 1 },
       { "name": "ابهر", "latitude": "36.80", "longitude": "49.130", "id": 2 },
@@ -891,6 +904,7 @@
     "center": "سمنان",
     "latitude": "35.340",
     "longitude": "53.230",
+    "landlinePrefix" : "023",
     "cities": [
       { "name": "سمنان", "latitude": "35.340", "longitude": "53.230", "id": 1 },
       { "name": "شاهرود", "latitude": "36.250", "longitude": "55.00", "id": 2 },
@@ -916,6 +930,7 @@
     "center": "زاهدان",
     "latitude": "29.320",
     "longitude": "60.540",
+    "landlinePrefix" : "054",
     "cities": [
       {
         "name": "زاهدان",
@@ -953,6 +968,7 @@
     "center": "شيراز",
     "latitude": "29.360",
     "longitude": "52.310",
+    "landlinePrefix" : "071",
     "cities": [
       { "name": "شيراز", "latitude": "29.360", "longitude": "52.310", "id": 1 },
       { "name": "اقليد", "latitude": "30.530", "longitude": "52.410", "id": 2 },
@@ -1073,6 +1089,7 @@
     "center": "قزوين",
     "latitude": "36.167",
     "longitude": "50.010",
+    "landlinePrefix" : "028",
     "cities": [
       { "name": "قزوين", "latitude": "36.167", "longitude": "50.010", "id": 1 },
       {
@@ -1096,6 +1113,7 @@
     "center": "قم",
     "latitude": "34.380",
     "longitude": "50.530",
+    "landlinePrefix" : "025",
     "cities": [
       { "name": "قم", "latitude": "34.380", "longitude": "50.530", "id": 1 },
       { "name": "قنوات", "latitude": "34.613", "longitude": "51.025", "id": 2 },
@@ -1126,6 +1144,7 @@
     "center": "کرج",
     "latitude": "35.8400",
     "longitude": "50.9391",
+    "landlinePrefix" : "026",
     "cities": [
       { "name": "کرج", "latitude": "35.8400", "longitude": "50.9391", "id": 1 },
       {
@@ -1162,6 +1181,7 @@
     "center": "سنندج",
     "latitude": "35.180",
     "longitude": "47.10",
+    "landlinePrefix" : "087",
     "cities": [
       { "name": "سنندج", "latitude": "35.180", "longitude": "47.10", "id": 1 },
       { "name": "بانه", "latitude": "35.590", "longitude": "45.540", "id": 2 },
@@ -1194,6 +1214,7 @@
     "center": "کرمان",
     "latitude": "30.160",
     "longitude": "57.40",
+    "landlinePrefix" : "034",
     "cities": [
       { "name": "کرمان", "latitude": "30.160", "longitude": "57.40", "id": 1 },
       { "name": "راور", "latitude": "31.150", "longitude": "56.510", "id": 2 },
@@ -1245,6 +1266,7 @@
     "center": "كرمانشاه",
     "latitude": "34.180",
     "longitude": "47.30",
+    "landlinePrefix" : "083",
     "cities": [
       {
         "name": "كرمانشاه",
@@ -1284,10 +1306,11 @@
     "id": 22
   },
   {
-    "name": "كهكيلويه و بويراحمد",
+    "name": "کهگیلویه و بويراحمد",
     "center": "ياسوج",
     "latitude": "30.390",
     "longitude": "51.350",
+    "landlinePrefix" : "074",
     "cities": [
       { "name": "ياسوج", "latitude": "30.390", "longitude": "51.350", "id": 1 },
       {
@@ -1322,6 +1345,7 @@
     "center": "گرگان",
     "latitude": "36.500",
     "longitude": "54.250",
+    "landlinePrefix" : "017",
     "cities": [
       { "name": "گرگان", "latitude": "36.500", "longitude": "54.250", "id": 1 },
       {
@@ -1369,6 +1393,7 @@
     "center": "رشت",
     "latitude": "37.160",
     "longitude": "49.350",
+    "landlinePrefix" : "013",
     "cities": [
       { "name": "رشت", "latitude": "37.160", "longitude": "49.350", "id": 1 },
       { "name": "منجيل", "latitude": "36.440", "longitude": "49.250", "id": 2 },
@@ -1427,6 +1452,7 @@
     "center": "خرم آباد",
     "latitude": "33.290",
     "longitude": "48.210",
+    "landlinePrefix" : "066",
     "cities": [
       {
         "name": "خرم آباد",
@@ -1486,6 +1512,7 @@
     "center": "ساري",
     "latitude": "36.330",
     "longitude": "53.30",
+    "landlinePrefix" : "011",
     "cities": [
       { "name": "ساري", "latitude": "36.330", "longitude": "53.30", "id": 1 },
       { "name": "آمل", "latitude": "36.280", "longitude": "52.220", "id": 2 },
@@ -1545,6 +1572,7 @@
     "center": "اراک",
     "latitude": "34.50",
     "longitude": "49.410",
+    "landlinePrefix" : "086",
     "cities": [
       { "name": "اراک", "latitude": "34.50", "longitude": "49.410", "id": 1 },
       { "name": "آشتيان", "latitude": "34.320", "longitude": "50.00", "id": 2 },
@@ -1567,6 +1595,7 @@
     "center": "بندرعباس",
     "latitude": "56.266",
     "longitude": "27.18",
+    "landlinePrefix" : "076",
     "cities": [
       {
         "name": "بندرعباس",
@@ -1617,6 +1646,7 @@
     "center": "همدان",
     "latitude": "34.470",
     "longitude": "48.300",
+    "landlinePrefix" : "081",
     "cities": [
       { "name": "همدان", "latitude": "34.470", "longitude": "48.300", "id": 1 },
       { "name": "ملاير", "latitude": "34.180", "longitude": "48.490", "id": 2 },
@@ -1642,6 +1672,7 @@
     "center": "يزد",
     "latitude": "31.530",
     "longitude": "54.210",
+    "landlinePrefix" : "035",
     "cities": [
       { "name": "يزد", "latitude": "31.530", "longitude": "54.210", "id": 1 },
       { "name": "تفت", "latitude": "31.450", "longitude": "54.120", "id": 2 },


### PR DESCRIPTION
**Changes made:**
Added landlinePrefix to iran_cities_with_coordinates.json and iran_cities_in_english.json.
Added landlinePrefix parameter in the API for states.
Implemented error handling to ensure the parameter starts with 0; otherwise, an error is returned.
Changed error messages from "most" to "must".
Corrected the word "کهکیلویه" to "کهگیلویه".